### PR TITLE
Fixes type of `note.page`

### DIFF
--- a/src/schemas/note.tsx
+++ b/src/schemas/note.tsx
@@ -20,7 +20,7 @@ const Note = {
     {
       name: "page",
       title: "Page",
-      type: "number",
+      type: "string",
     },
   ],
   preview: {


### PR DESCRIPTION
Changes `note.page` from number to string, allowing for roman numerals and other, more flexible inputs.