### PR TITLE
Fix client deopt

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,17 +1,16 @@
 import { getHomepage, getNotesAndPosts } from "src/data/getHomepage";
-import { type SearchResponse, search } from "src/data/search";
 import NoteItem from "src/components/note-item";
 import PostItem from "src/components/post";
 import Reading from "src/components/reading";
 import list from "src/styles/list.module.css";
 import Search from "src/components/search";
 
-export default async function HomePage() {
+export default async function HomePage({ searchParams }) {
   const { reading, read } = await getHomepage();
   const notesAndPosts = await getNotesAndPosts();
   return (
     <>
-      <Search floatResults />
+      <Search query={searchParams.query} floatResults />
       <Reading reading={reading} read={read} />
       <ul className={list.noStyle}>
         {notesAndPosts.map((item) => {

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -2,6 +2,9 @@
 
 import {
   ChangeEvent,
+  ChangeEventHandler,
+  MouseEventHandler,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -9,14 +12,14 @@ import {
   useState,
 } from "react";
 import cx from "classnames";
-import { Search } from "lucide-react";
+import { Search as SearchIcon } from "lucide-react";
 import useSearch from "./useSearch";
 import styles from "./search.module.css";
 import SearchResultItem from "./search-result";
 import type { SearchResponse } from "src/data/search";
 import useClickOutside from "src/hooks/useClickOutside";
 
-export interface SearchInputProps {
+export interface SearchProps {
   className?: string;
   query?: string;
   searchResponse?: SearchResponse;
@@ -56,7 +59,28 @@ function useSearchResults(
   };
 }
 
-export default function SearchInput(props: SearchInputProps) {
+interface SearchInputProps {
+  query?: string;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  onClick: MouseEventHandler<HTMLInputElement>;
+}
+
+function SearchInput({ query, onChange, onClick }: SearchInputProps) {
+  return (
+    <input
+      id='search'
+      type='search'
+      name='query'
+      value={query ?? ""}
+      placeholder='Search'
+      className={cx(styles.searchInput)}
+      onChange={onChange}
+      onClick={onClick}
+    />
+  );
+}
+
+export default function Search(props: SearchProps) {
   const {
     className,
     query: initialQuery,
@@ -104,6 +128,9 @@ export default function SearchInput(props: SearchInputProps) {
     setQuery(value);
   };
 
+  const onInputClick = () =>
+    setShowResults(Boolean((query && results) || error));
+
   return (
     <div className={cx(styles.container, className)}>
       <form
@@ -117,18 +144,19 @@ export default function SearchInput(props: SearchInputProps) {
           className={cx(styles.searchInputLabel)}
           title='Search'
         >
-          <Search />
+          <SearchIcon />
         </label>
-        <input
-          id='search'
-          type='search'
-          name='query'
-          value={query}
-          placeholder='Search'
-          className={cx(styles.searchInput)}
-          onChange={onInputChange}
-          onClick={() => setShowResults(Boolean((query && results) || error))}
-        />
+        <Suspense
+          fallback={
+            <SearchInput onChange={onInputChange} onClick={onInputClick} />
+          }
+        >
+          <SearchInput
+            query={query}
+            onChange={onInputChange}
+            onClick={onInputClick}
+          />
+        </Suspense>
       </form>
       {showResults && (
         <div

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -146,17 +146,11 @@ export default function Search(props: SearchProps) {
         >
           <SearchIcon />
         </label>
-        <Suspense
-          fallback={
-            <SearchInput onChange={onInputChange} onClick={onInputClick} />
-          }
-        >
-          <SearchInput
-            query={query}
-            onChange={onInputChange}
-            onClick={onInputClick}
-          />
-        </Suspense>
+        <SearchInput
+          query={query}
+          onChange={onInputChange}
+          onClick={onInputClick}
+        />
       </form>
       {showResults && (
         <div

--- a/src/components/search/useSearch.ts
+++ b/src/components/search/useSearch.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { SearchResponse } from "src/data/search";
 
 export default function useSearch(
@@ -9,21 +9,13 @@ export default function useSearch(
   initialResponse?: SearchResponse
 ) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const queryParam = searchParams?.get("query");
 
-  const [query, setQuery] = useState(initialQuery ?? queryParam ?? "");
+  const [query, setQuery] = useState(initialQuery ?? "");
   const [response, setResponse] = useState(initialResponse);
 
   const formRef = useRef<HTMLFormElement>(null);
   const prevQuery = useRef<string>(query);
   const firstRun = useRef<boolean>(true);
-
-  useEffect(() => {
-    if (queryParam && queryParam !== prevQuery.current) {
-      setQuery(queryParam);
-    }
-  }, [queryParam]);
 
   const runSearch = useCallback(async () => {
     if (query !== prevQuery.current || firstRun.current) {


### PR DESCRIPTION
By using `useSearchParams` in the `useSearch` hook, I broke static rendering by deopting the entire site into client-side rendering. https://nextjs.org/docs/app/api-reference/functions/use-search-params#static-rendering

This removes the `useSearchParams` use to fix this. The downside is that I need to pass in the search query from any page that loads the search bar. There may be a better way to unite the hook with the component to allow for a "dumber" component that isn't always aware of the URL query string until the client-side code loads.